### PR TITLE
Add onAttach(Activity activity) method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,13 @@ android:
   - extra
   - android-23
   - build-tools-27.0.3
+licenses:
+- android-sdk-preview-license-.+
+- android-sdk-license-.+
+- google-gdk-license-.+
 
+before_install: 
+- yes | /usr/local/android-sdk/tools/bin/sdkmanager "platforms;android-26"
+- chmod +x gradlew
 script:
 - ./gradlew clean build -x test

--- a/app/src/main/java/com/microsoft/graph/snippets/SnippetListFragment.java
+++ b/app/src/main/java/com/microsoft/graph/snippets/SnippetListFragment.java
@@ -12,7 +12,7 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.ListView;
-
+import android.app.Activity;
 public class SnippetListFragment extends ListFragment {
 
     private static final String STATE_ACTIVATED_POSITION = "activated_position";

--- a/app/src/main/java/com/microsoft/graph/snippets/SnippetListFragment.java
+++ b/app/src/main/java/com/microsoft/graph/snippets/SnippetListFragment.java
@@ -76,6 +76,20 @@ public class SnippetListFragment extends ListFragment {
         mCallbacks = (Callbacks) context;
     }
 
+    
+    @Override
+    public void onAttach(Activity activity) {
+        super.onAttach(activity);
+
+        // Activities containing this fragment must implement its callbacks.
+        if (!(activity instanceof Callbacks)) {
+            throw new IllegalStateException("Activity must implement fragment's callbacks.");
+        }
+        
+        mCallbacks = (Callbacks) activity;
+    }
+
+    
     @Override
     public void onDetach() {
         super.onDetach();


### PR DESCRIPTION
This PR keeps compatibility with android API 21. 

The [device requirement part](https://github.com/microsoftgraph/android-java-snippets-sample#device-requirements) of the readme indicates that you must have an android device API 21 or higher.
However this project is not directly compatible because the method `onAttach(Activity activity)` not exist, there is only `onAttach(Context context)` method. 

`onAttach(Context context)` is [called only since API 23](https://developer.android.com/reference/android/app/Fragment.html#onAttach(android.app.Activity)). 

So, this PR adds the `onAttach(Activity activity)`. 
